### PR TITLE
Handle empty log lines in OutputWatcher

### DIFF
--- a/src/C3D/Extensions/Aspire/OutputWatcher/ResourceOutputWatcherService.cs
+++ b/src/C3D/Extensions/Aspire/OutputWatcher/ResourceOutputWatcherService.cs
@@ -50,8 +50,6 @@ public class ResourceOutputWatcherService : BackgroundService
 
     private async Task WatchResourceAsync(IResource resource, CancellationToken stoppingToken)
     {
-        
-
         logger.LogInformation("Waiting for {Resource} output", resource.Name);
         if (resource.TryGetAnnotationsOfType<OutputWatcherAnnotationBase>(out var annotations))
         {
@@ -77,14 +75,17 @@ public class ResourceOutputWatcherService : BackgroundService
                     }
                     try
                     {
-                        var message = DateTimeOffset.TryParseExact(
-                            line.Content.AsSpan()[..ConsoleLogsTimestampFormatLength], ConsoleLogsTimestampFormat,
-                            CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out var timeStamp)
-                            ? line.Content[MessageStartOffset..] : line.Content;
-
-                        foreach (var annotation in annotations)
+                        if (!string.IsNullOrEmpty(line.Content))
                         {
-                            await ProcessLineAsync(resource, annotation, timeStamp, message, stoppingToken);
+                            var message = DateTimeOffset.TryParseExact(
+                                line.Content.AsSpan()[..ConsoleLogsTimestampFormatLength], ConsoleLogsTimestampFormat,
+                                CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out var timeStamp)
+                                ? line.Content[MessageStartOffset..] : line.Content;
+
+                            foreach (var annotation in annotations)
+                            {
+                                await ProcessLineAsync(resource, annotation, timeStamp, message, stoppingToken);
+                            }
                         }
                     }
                     catch (Exception e)


### PR DESCRIPTION
Handler empty log lines

#### PR Classification
Code cleanup and logic restructuring in the `ResourceOutputWatcherService`.

#### PR Summary
The pull request refines the `WatchResourceAsync` method by improving the handling of line content and annotations. It ensures that message processing occurs only for non-empty content and restructures the logic for clarity and efficiency.
- `ResourceOutputWatcherService.cs`: Removed the conditional check for empty content and moved timestamp parsing inside the annotation processing loop.
