### PR TITLE
Remove envdte from IISExpress project

### DIFF
--- a/src/C3D/Extensions/Aspire/IISExpress/C3D.Extensions.Aspire.IISExpress.csproj
+++ b/src/C3D/Extensions/Aspire/IISExpress/C3D.Extensions.Aspire.IISExpress.csproj
@@ -9,7 +9,6 @@
 
   <ItemGroup>
     <PackageReference Include="Aspire.Hosting" Version="9.2.0" />
-    <PackageReference Include="envdte" Version="17.13.40008" />
     <ProjectReference Include="..\VisualStudioDebug\C3D.Extensions.Aspire.VisualStudioDebug.csproj" />
     <None Include="build\*.*" Pack="true" PackagePath="build\%(Filename)%(Extension)" Visible="true" />
   </ItemGroup>


### PR DESCRIPTION
This is only needed in the VisualStudio debug related packages and
doesn't need to be available directly in this project.
