### PR TITLE
Handle case where SolutionName is not set (or set to *Undefined*)

### DIFF
--- a/C3D.Extensions.Aspire.sln
+++ b/C3D.Extensions.Aspire.sln
@@ -20,6 +20,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{E1FFCD98
 		build\nuget.publish.config = build\nuget.publish.config
 		README.md = README.md
 		build\RemoveCert.ps1 = build\RemoveCert.ps1
+		Set-WebApplicationTargetsPath.ps1 = Set-WebApplicationTargetsPath.ps1
 		build\Test.snk = build\Test.snk
 	EndProjectSection
 EndProject

--- a/Set-WebApplicationTargetsPath.ps1
+++ b/Set-WebApplicationTargetsPath.ps1
@@ -1,0 +1,5 @@
+$vs_path = vswhere -latest -property installationPath
+$vs_version = [System.Version]::Parse($(vswhere -latest -property installationVersion))
+$vs_tools_path = "$vs_path\MSBuild\Microsoft\VisualStudio\v$($vs_version.Major).0"
+$web_applications_target_path = "$vs_tools_path\WebApplications\Microsoft.WebApplication.targets"
+$env:WebApplicationsTargetPath=$web_applications_target_path

--- a/src/C3D/Extensions/Aspire/IISExpress/IISEndPointConfigurator.cs
+++ b/src/C3D/Extensions/Aspire/IISExpress/IISEndPointConfigurator.cs
@@ -28,7 +28,7 @@ internal class IISEndPointConfigurator
 
     public void Configure()
     {
-        var appHostConfig = options.Value.ApplicationHostConfig!;
+        var appHostConfig = options.Value.ApplicationHostConfig ?? ApplicationHostConfigurationExtensions.GetTempConfigFile();
         foreach (var project in appModel.Resources.OfType<IISExpressProjectResource>())
         {
             try

--- a/src/C3D/Extensions/Aspire/IISExpress/IISExpressOptions.cs
+++ b/src/C3D/Extensions/Aspire/IISExpress/IISExpressOptions.cs
@@ -89,7 +89,12 @@ public class IISExpressOptions : IValidatableObject
         return results;
     }
 
-    public string? ApplicationHostConfig => SolutionDir is null || SolutionName is null ? null :
+    public string? ApplicationHostConfig => 
+        (string.IsNullOrEmpty(SolutionDir) || 
+            (string.IsNullOrEmpty(SolutionName) ||
+                SolutionName.IndexOfAny(Path.GetInvalidFileNameChars())!=-1
+            )
+        ) ? null :
         System.IO.Path.Combine(
             SolutionDir,
             ".vs",


### PR DESCRIPTION
Handle case where SolutionName is not set (or set to *Undefined*)

Fixes #32


#### PR Classification
New feature implementation for improved configuration handling in the project.

#### PR Summary
This pull request introduces a new PowerShell script for setting web application targets and enhances the configuration logic in existing classes. 
- `C3D.Extensions.Aspire.sln`: Added `Set-WebApplicationTargetsPath.ps1` to the build section.
- `Set-WebApplicationTargetsPath.ps1`: Implemented logic to retrieve Visual Studio installation path and set the `WebApplicationsTargetPath` environment variable.
- `IISEndPointConfigurator.cs`: Modified `Configure` method to use a fallback for `ApplicationHostConfig`.
- `IISExpressOptions.cs`: Improved validation for `ApplicationHostConfig` to check for null, empty values, and invalid characters.
